### PR TITLE
Add request logging middleware

### DIFF
--- a/BookCRUD.Server/Program.cs
+++ b/BookCRUD.Server/Program.cs
@@ -22,6 +22,7 @@ namespace BookCRUD.Service
                 app.UseSwaggerUI();
             }
 
+            app.UseRequestLogging();
             app.UseHttpsRedirection();
 
             app.UseAuthorization();

--- a/BookCRUD.Server/RequestLoggingMiddleware.cs
+++ b/BookCRUD.Server/RequestLoggingMiddleware.cs
@@ -1,0 +1,32 @@
+namespace BookCRUD.Server
+{
+    public class RequestLoggingMiddleware
+    {
+        private readonly RequestDelegate _next;
+        private readonly ILogger<RequestLoggingMiddleware> _logger;
+
+        public RequestLoggingMiddleware(RequestDelegate next, ILogger<RequestLoggingMiddleware> logger)
+        {
+            _next = next;
+            _logger = logger;
+        }
+
+        public async Task InvokeAsync(HttpContext context)
+        {
+            _logger.LogInformation($"Incoming request: {context.Request.Method} {context.Request.Path}");
+
+            await _next(context);
+
+            _logger.LogInformation($"Outgoing response: {context.Response.StatusCode}");
+        }
+    }
+
+    public static class RequestLoggingMiddlewareExtensions
+    {
+        public static IApplicationBuilder UseRequestLogging(
+            this IApplicationBuilder builder)
+        {
+            return builder.UseMiddleware<RequestLoggingMiddleware>();
+        }
+    }
+}


### PR DESCRIPTION
This commit introduces a new middleware component, `RequestLoggingMiddleware`, to the BookCRUD.Server project.

The middleware logs incoming request details (method and path) and outgoing response status codes. This provides basic observability into the server's request handling.

The middleware is registered in `Program.cs` to be part of the HTTP request pipeline.